### PR TITLE
:bug: Fix missing cors headers when an excpetion was trown

### DIFF
--- a/Nancy.Scaffolding/Bootstrapper.cs
+++ b/Nancy.Scaffolding/Bootstrapper.cs
@@ -183,6 +183,20 @@ namespace Nancy.Scaffolding
                        .WithHeader("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS,POST,PUT,DELETE")
                        .WithHeader("Access-Control-Allow-Headers", "Content-Type, Accept, Authorization");
             });
+
+            pipelines.OnError.AddItemToStartOfPipeline((context, ex) =>
+            {
+                var response = context.Response ?? new Response();
+
+                context.Response
+                      .WithHeader("Access-Control-Allow-Origin", "*")
+                      .WithHeader("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS,POST,PUT,DELETE")
+                      .WithHeader("Access-Control-Allow-Headers", "Content-Type, Accept, Authorization");
+
+                context.Response = response;
+
+                return null;
+            });
         }
 
         protected void EnableCSRF(IPipelines pipelines)


### PR DESCRIPTION
![Who are you?](https://media.giphy.com/media/3ohc10GA6j4XrLWzZK/giphy.gif)

### Whats?

CORS headers ware not being setted when an exception was thrown. Now it is
